### PR TITLE
enum 提示问题

### DIFF
--- a/EmmyLua.Unity.Cli/Generator/XLua/XLuaDumper.cs
+++ b/EmmyLua.Unity.Cli/Generator/XLua/XLuaDumper.cs
@@ -301,7 +301,7 @@ public class XLuaDumper : IDumper
         sb.AppendLine($"---@enum (key) {classFullName}");
         foreach (var csTypeField in csEnumType.Fields)
         {
-            sb.AppendLine($"---| CS.{csEnumType.Name}.{csTypeField.Name}");
+            sb.AppendLine($"---| {csTypeField.Name}");
         }
     }
 


### PR DESCRIPTION
下面这种enum会出现提示的不正确的情况，只需要 csTypeField.Name 即可
![image](https://github.com/user-attachments/assets/13537de2-5a08-4571-a4ab-90c56bcd7bab)
![image](https://github.com/user-attachments/assets/9bed2119-3aa7-4871-a95a-852e0b36d03b)
